### PR TITLE
📁 XDG spec and NOTESH_FILE envvar for default file

### DIFF
--- a/notesh/command_line.py
+++ b/notesh/command_line.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 
 from notesh.main import NoteApp
 
-
 def run():
     import argparse
 
     parser = argparse.ArgumentParser(description="Run Sticky Notes in your Terminal!")
-    parser.add_argument("-f", "--file", default="notes.json", required=False)
+    parser.add_argument("-f", "--file", default=NoteApp.DEFAULT_FILE, help=f"Notes file to use. Defaults to $NOTESH_FILE or $XDG_DATA_HOME/notesh/notes.json (currently: {NoteApp.DEFAULT_FILE!r})", required=False)
     argsx = parser.parse_args()
     NoteApp(file=argsx.file).run()
 

--- a/notesh/command_line.py
+++ b/notesh/command_line.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 
 from notesh.main import NoteApp
 
+
 def run():
     import argparse
 
     parser = argparse.ArgumentParser(description="Run Sticky Notes in your Terminal!")
-    parser.add_argument("-f", "--file", default=NoteApp.DEFAULT_FILE, help=f"Notes file to use. Defaults to $NOTESH_FILE or $XDG_DATA_HOME/notesh/notes.json (currently: {NoteApp.DEFAULT_FILE!r})", required=False)
+    parser.add_argument(
+        "-f",
+        "--file",
+        default=NoteApp.DEFAULT_FILE,
+        help=f"Notes file to use. Defaults to $NOTESH_FILE or $XDG_DATA_HOME/notesh/notes.json (currently: {NoteApp.DEFAULT_FILE!r})",
+        required=False,
+    )
     argsx = parser.parse_args()
     NoteApp(file=argsx.file).run()
 

--- a/notesh/main.py
+++ b/notesh/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Optional, Type
 
@@ -27,12 +28,17 @@ class NoteApp(App):
         Binding("ctrl+c", "quit", "Quit"),
     ]
 
+    DEFAULT_FILE = os.environ.get(
+        "NOTESH_FILE",
+        str(Path(os.environ.get("XDG_DATA_HOME", Path("~/.local/share").expanduser())) / "notesh" / "notes.json"),
+    )
+
     def __init__(
         self,
         driver_class: Type[Driver] | None = None,
         css_path: CSSPathType = None,
         watch_css: bool = False,
-        file: str = "notes.json",
+        file: str = DEFAULT_FILE,
     ):
         super().__init__(driver_class, css_path, watch_css)
         self.file = file

--- a/notesh/main.py
+++ b/notesh/main.py
@@ -13,8 +13,7 @@ from textual.widgets import Footer
 
 from notesh.drawables.drawable import Drawable
 from notesh.play_area import PlayArea
-from notesh.utils import (calculate_size_for_file, load_binding_config_file,
-                          load_drawables, save_drawables, set_bindings)
+from notesh.utils import calculate_size_for_file, load_binding_config_file, load_drawables, save_drawables, set_bindings
 from notesh.widgets.sidebar import DeleteDrawable, Sidebar
 from notesh.widgets.sidebar_left import SidebarLeft
 

--- a/notesh/main.py
+++ b/notesh/main.py
@@ -29,7 +29,15 @@ class NoteApp(App):
 
     DEFAULT_FILE = os.environ.get(
         "NOTESH_FILE",
-        str(Path(os.environ.get("XDG_DATA_HOME", Path("~/.local/share").expanduser())) / "notesh" / "notes.json"),
+        str(
+            (
+                Path(os.getenv("APPDATA", Path.home()))
+                if os.name == "nt"
+                else Path(os.getenv("XDG_DATA_HOME", Path("~/.local/share").expanduser()))
+            )
+            / "notesh"
+            / "notes.json"
+        ),
     )
 
     def __init__(

--- a/notesh/play_area.py
+++ b/notesh/play_area.py
@@ -15,7 +15,6 @@ from textual.widgets import Static
 from notesh.drawables.box import Box
 from notesh.drawables.drawable import Drawable
 from notesh.drawables.sticknote import Note
-from notesh.drawables.back import Back
 
 CHUNK_SIZE = Offset(20, 5)
 
@@ -77,7 +76,7 @@ class PlayArea(Container):
         widgets["border_color_picker"].update_colors(self.border_color)
 
     def add_new_drawable(self, drawable_type: str) -> Drawable:
-        d = {"note": Note, "box": Box, "back": Back}
+        d = {"note": Note, "box": Box}
         drawable = cast(Drawable, d.get(drawable_type, Drawable)())
         self._mount_drawable(drawable)
 

--- a/notesh/play_area.py
+++ b/notesh/play_area.py
@@ -60,7 +60,7 @@ class PlayArea(Container):
         else:
             self.border_color = base_color
         self.update_layout(duration)
-    
+
     def update_layout(self, duration: float = 1.0):
         base_color = self.color
         border_color = self.border_color

--- a/notesh/utils.py
+++ b/notesh/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import sys
 import uuid
 from functools import partial
@@ -60,6 +61,7 @@ def save_drawables(file_name: str, drawables: list[Drawable], layers: list[str],
     if background is not None:
         obj["background"] = background
 
+    Path(file_name).parent.mkdir(parents=True, exist_ok=True)
     with open(file_name, "w") as file:
         json.dump(obj, file, indent=4)
 

--- a/notesh/utils.py
+++ b/notesh/utils.py
@@ -47,7 +47,9 @@ def calculate_size_for_file(file_name: str) -> tuple[Size, Size]:
     return Size(mnx, mny), Size(mxx, mxy)
 
 
-def save_drawables(file_name: str, drawables: list[Drawable], layers: list[str], background: Optional[dict[Any, Any]] = None) -> None:
+def save_drawables(
+    file_name: str, drawables: list[Drawable], layers: list[str], background: Optional[dict[Any, Any]] = None
+) -> None:
     obj: dict[str, Any] = {"layers": []}
     layers_set: set[str] = set()
     drawable: Drawable
@@ -77,7 +79,7 @@ def load_drawables(file_name: str) -> tuple[list[tuple[str, dict[Any, Any]]], Op
         return [], None
 
     background = None
-    if "background" in obj: 
+    if "background" in obj:
         background = obj["background"]
 
     keys = [x for x in obj.keys() if x not in ["background", "layers"]]

--- a/notesh/widgets/sidebar.py
+++ b/notesh/widgets/sidebar.py
@@ -109,12 +109,12 @@ class Sidebar(Vertical):
                 if child.has_class("-hidden"):
                     continue
                 # Should be change to something pretier
-                if isinstance(child, MultilineArray): 
+                if isinstance(child, MultilineArray):
                     return child.lines[0]
                 else:
                     return child
             return None
-        child: Widget = list(self.widget_list.values())[index%len(self.widget_list)]
+        child: Widget = list(self.widget_list.values())[index % len(self.widget_list)]
         if child.has_class("-hidden"):
             return None
         return child


### PR DESCRIPTION
This PR introduces a `$NOTESH_FILE` environment variable that controls
the default file Notesh opens. It defaults to `$XDG_DATA_HOME`
(which itself defaults to `~/.local/share`) and can of course still be
overridden by the user via `notesh -f FILE`.

This causes `notesh` to always open the default notes file, no matter
what directory one is in. The user can change the default location by
setting the `$NOTESH_FILE` envvar in their shell config. Setting
`NOTESH_FILE=notes.json` restores the old behaviour.
